### PR TITLE
Added method Node.copy(), which copies a node and all parents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
 "numpy>=2",
 "scipy",
 "networkx",
+"seaborn",
+"pandas",
 ]  
 
 [project.optional-dependencies]

--- a/src/probabilit/inspection.py
+++ b/src/probabilit/inspection.py
@@ -4,3 +4,34 @@ Inspection
 
 Inspection of results, plotting, tables, exporting, etc.
 """
+
+import seaborn
+import pandas as pd
+from probabilit.modeling import Add, Distribution
+import numpy as np
+
+
+def plot(*variables, corr=None, **kwargs):
+    """Utility function for quick plotting of one or several variables."""
+    # TODO: This function can be improved or customized. For now we use seaborn
+
+    # Create an adder node, then copy the adder (which copies all parents too)
+    # This prevents us from mutating the input arguments
+    adder = Add(*variables).copy()
+    variables = adder.parents  # Get reference back to the variables
+    adder.sample(size=999, random_state=42)  # Sample to populate _samples
+
+    df = pd.DataFrame(
+        {f"var_{i}": var.samples_ for (i, var) in enumerate(variables, 1)}
+    )
+    return seaborn.pairplot(df, **kwargs)
+
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(42)
+    # mu = Constant(1)
+    a = Distribution("norm", loc=0, scale=1)
+    b = Distribution("norm", loc=a, scale=0.5)
+
+    plot(a, b)
+    grid = plot(a)

--- a/src/probabilit/modeling.py
+++ b/src/probabilit/modeling.py
@@ -267,7 +267,6 @@ class Node(abc.ABC):
                 copied.kwargs = {k: update(v) for (k, v) in copied.kwargs.items()}
             elif isinstance(copied, (VariadicTransform, BinaryTransform)):
                 copied.parents = tuple(update(p) for p in copied.parents)
-
             elif isinstance(copied, UnaryTransform):
                 copied.parent = update(copied.parent)
             elif isinstance(copied, Constant):

--- a/src/probabilit/modeling.py
+++ b/src/probabilit/modeling.py
@@ -126,6 +126,7 @@ import abc
 import itertools
 import networkx as nx
 from scipy._lib._util import check_random_state
+import copy
 
 
 # =============================================================================
@@ -226,6 +227,55 @@ class Node(abc.ABC):
 
     def __hash__(self):
         return self._id
+
+    def copy(self):
+        """Copy the Node, including the entire graph above it.
+
+        Examples
+        --------
+        >>> mu = Distribution("norm", loc=0, scale=1)
+        >>> a = Distribution("norm", loc=mu, scale=Constant(0.5))
+        >>> a2 = a.copy()
+        >>> a is a2
+        False
+        >>> a2.kwargs["loc"] == a.kwargs["loc"]
+        True
+        >>> a2.kwargs["loc"] is a.kwargs["loc"]
+        False
+
+        """
+        # Map from ID to new object copy
+        id_to_new = dict()
+
+        def update(item):
+            """Given an item, use the ID to map to new object copy."""
+            if isinstance(item, Node):
+                return id_to_new[item._id]
+            return item
+
+        # Go through nodes in topologial order, guaranteeing that parents
+        # have always been copied over to new graph when children are copied.
+        for node in nx.topological_sort(self.to_graph()):
+            # Copy the node itself and update the mapping
+            copied = copy.copy(node)  # Copy a node WITHOUT copying the graph
+            id_to_new[copied._id] = copied
+
+            # Now that the node has been updated, update references to parents
+            # to point to Nodes in the new copied graph instead of the old one.
+            if isinstance(copied, Distribution):
+                copied.args = tuple(update(arg) for arg in copied.args)
+                copied.kwargs = {k: update(v) for (k, v) in copied.kwargs.items()}
+            elif isinstance(copied, (VariadicTransform, BinaryTransform)):
+                copied.parents = tuple(update(p) for p in copied.parents)
+
+            elif isinstance(copied, UnaryTransform):
+                copied.parent = update(copied.parent)
+            elif isinstance(copied, Constant):
+                copied.value = update(copied.value)
+            else:
+                pass
+
+        return id_to_new[self._id]
 
     def nodes(self):
         """Yields `self` and all ancestors using depth-first-search.

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -1,5 +1,23 @@
-from probabilit.modeling import Constant, Log, Exp
+from probabilit.modeling import Constant, Log, Exp, Distribution
 import numpy as np
+
+
+def test_copying():
+    # Create a graph
+    mu = Distribution("norm", loc=0, scale=1)
+    a = Distribution("norm", loc=mu, scale=Constant(0.5))
+
+    # Create a copy
+    a2 = a.copy()
+
+    # The copy is not the same object
+    assert a2 is not a
+
+    # However, the IDs match and they are equal
+    assert a2 == a and (a2._id == a._id)
+
+    # The same holds for parents - they are copied
+    assert a2.kwargs["loc"] is not a.kwargs["loc"]
 
 
 def test_constant_arithmetic():

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -23,6 +23,11 @@ def test_copying():
     assert hasattr(a, "samples_")
     assert not hasattr(a2, "samples_")
 
+    # Now create a copy and ensure samples are copied too
+    a3 = a.copy()
+    assert hasattr(a3, "samples_")
+    assert a3.samples_ is not a.samples_
+
 
 def test_constant_arithmetic():
     # Test that converstion with int works

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -19,6 +19,10 @@ def test_copying():
     # The same holds for parents - they are copied
     assert a2.kwargs["loc"] is not a.kwargs["loc"]
 
+    a.sample()
+    assert hasattr(a, "samples_")
+    assert not hasattr(a2, "samples_")
+
 
 def test_constant_arithmetic():
     # Test that converstion with int works


### PR DESCRIPTION
- Drafted a quick plotting function
- Needed a copy method to avoid mutating input args in plotting function. This is a bit more involved than a typical copy, since we need to copy the whole graph and references over.