### PR TITLE
Make Lognormal and other distributions work with composite args

### DIFF
--- a/src/probabilit/distributions.py
+++ b/src/probabilit/distributions.py
@@ -1,19 +1,22 @@
 import numpy as np
 import warnings
 import scipy as sp
-from probabilit.modeling import Distribution
+from probabilit.modeling import Distribution, Log, Exp, Sign
 
 
 def Uniform(min=0, max=1):
+    """Uniform distribution on [min, max)."""
     return Distribution("uniform", loc=min, scale=max - min)
 
 
 def Normal(loc, scale):
+    """Normal distribution parametrized by mean (loc) and std (scale)."""
     return Distribution("norm", loc=loc, scale=scale)
 
 
 def TruncatedNormal(loc, scale, low, high):
-    """A truncated Normal distribution.
+    """A truncated Normal distribution parametrized by mean (loc) and
+    std (scale) defined on [low, high).
 
     Examples
     --------
@@ -26,24 +29,34 @@ def TruncatedNormal(loc, scale, low, high):
     return Distribution("truncnorm", a=a, b=b, loc=loc, scale=scale)
 
 
-class Lognormal:
+class Lognormal(Distribution):
     def __init__(self, mean, std):
         """
-        Create a lognormal distribution with specified mean and standard deviation.
-        Parameters correspond directly to the mean and standard deviation
-        of the resulting lognormal distribution.
+        A Lognormal distribution with mean and std corresponding directly
+        to the expected value and standard deviation of the resuling lognormal.
+
+        Examples
+        --------
+        >>> samples = Lognormal(mean=2, std=1).sample(999, random_state=0)
+        >>> float(np.mean(samples))
+        2.00173...
+        >>> float(np.std(samples))
+        1.02675...
+
+        Composite distributions work too:
+
+        >>> mean = Distribution("expon", scale=1)
+        >>> Lognormal(mean=mean, std=1).sample(5, random_state=0)
+        array([0.86196529, 0.69165866, 0.41782557, 1.23340656, 2.90778578])
         """
-        assert mean > 0, f"Mean must be positive, got {mean}"
-        assert std > 0, f"Standard deviation must be positive, got {std}"
-        assert np.isfinite(mean), f"Mean must be finite, got {mean}"
-        assert np.isfinite(std), f"Standard deviation must be finite, got {std}"
+        # Transform parameters (they can be numbers, distributions, etc)
+        variance = Sign(std) * std**2  # Square it but keep the sign (so negative fails)
+        sigma_squared = Log(1 + variance / (mean**2))
+        sigma = (sigma_squared) ** (1 / 2)
+        mu = Log(mean) - sigma_squared / 2
 
-        variance = std**2
-        sigma_squared = np.log(1 + variance / (mean**2))
-        sigma = np.sqrt(sigma_squared)
-        mu = np.log(mean) - sigma_squared / 2
-
-        self.distribution = Distribution("lognorm", s=sigma, scale=np.exp(mu))
+        # Call the parent class
+        super().__init__(distr="lognorm", s=sigma, scale=Exp(mu))
 
     @classmethod
     def from_log_params(cls, mu, sigma):
@@ -52,18 +65,14 @@ class Lognormal:
         Parameters correspond to the mean and standard deviation of the
         underlying normal distribution (i.e., the parameters of log(X) where
         X is the lognormal random variable).
+
+        Examples
+        --------
+        >>> mu = Distribution("norm")
+        >>> Lognormal.from_log_params(mu=mu, sigma=1).sample(5, random_state=0)
+        array([1.99625633, 1.45244764, 1.19926216, 2.94150961, 4.47459182])
         """
-        assert np.isfinite(mu), f"Mu must be finite, got {mu}"
-        assert sigma > 0, f"Sigma must be positive, got {sigma}"
-        assert np.isfinite(sigma), f"Sigma must be finite, got {sigma}"
-
-        # Create a dummy instance and set its distribution
-        instance = cls.__new__(cls)
-        instance.distribution = Distribution("lognorm", s=sigma, scale=np.exp(mu))
-        return instance
-
-    def __getattr__(self, name):
-        return getattr(self.distribution, name)
+        return Distribution("lognorm", s=sigma, scale=Exp(mu))
 
 
 def PERT(minimum, mode, maximum, gamma=4.0):

--- a/src/probabilit/distributions.py
+++ b/src/probabilit/distributions.py
@@ -33,7 +33,7 @@ class Lognormal(Distribution):
     def __init__(self, mean, std):
         """
         A Lognormal distribution with mean and std corresponding directly
-        to the expected value and standard deviation of the resuling lognormal.
+        to the expected value and standard deviation of the resulting lognormal.
 
         Examples
         --------

--- a/src/probabilit/modeling.py
+++ b/src/probabilit/modeling.py
@@ -425,7 +425,7 @@ class Node(abc.ABC):
             # Sample all ancestors of ISNs
             ancestors = G.subgraph(nx.ancestors(G, node))
             for ancestor in nx.topological_sort(ancestors):
-                assert isinstance(ancestor, (Constant, AbstractDistribution))
+                assert isinstance(ancestor, (Constant, Transform))
                 ancestor.samples_ = ancestor._sample(size=size)
 
             # Sample the ISN
@@ -965,6 +965,10 @@ class Floor(UnaryTransform):
 
 class Ceil(UnaryTransform):
     op = np.ceil
+
+
+class Sign(UnaryTransform):
+    op = np.sign
 
 
 class ScalarFunctionTransform(Transform):

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -95,15 +95,6 @@ class TestLognormal:
         np.testing.assert_allclose(np.mean(samples), expected_mean, rtol=0.05)
         np.testing.assert_allclose(np.std(samples), expected_std, rtol=0.05)
 
-    def test_lognormal_invalid_inputs(self):
-        # Test input validation
-        with pytest.raises(AssertionError, match="Mean must be positive"):
-            Lognormal(-1, 5)
-        with pytest.raises(AssertionError, match="Standard deviation must be positive"):
-            Lognormal(10, -2)
-        with pytest.raises(AssertionError, match="Mean must be finite"):
-            Lognormal(np.inf, 5)
-
 
 class TestPERT:
     @pytest.mark.parametrize("gamma", [1, 3, 4, 7])

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -305,6 +305,23 @@ def test_that_an_empirical_distribution_can_be_a_parameter():
     (result**2).sample(99, random_state=42)
 
 
+def test_that_distribution_params_with_transforms():
+    # Plain old numbers work as arguments without raising any errors
+    loc = 2
+    samples1 = Distribution("norm", loc=loc).sample(99, random_state=0)
+
+    # The same number wrapped in constant
+    loc = Constant(2)
+    samples2 = Distribution("norm", loc=loc).sample(99, random_state=0)
+
+    # A more complex expression: loc = 0 + sqrt(9) - Log(2) = 0 + 3 - 1 = 2
+    loc = Constant(0) + (Constant(9) ** 0.5) - Log(2.718281828459045)
+    samples3 = Distribution("norm", loc=loc).sample(99, random_state=0)
+
+    np.testing.assert_allclose(samples1, samples2)
+    np.testing.assert_allclose(samples1, samples3)
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
- The tests for valid inputs were removed in order to account for non-number args. Currently bad input will fail/raise warnings deeper down at the numpy/scipy level. If we want to we can consider "catching it" by `np.seterr` or similar. But I think we should always delegate input checking to scipy instead of implementing our own.