### PR TITLE
Add inspection.treeprint for printing models

### DIFF
--- a/src/probabilit/modeling.py
+++ b/src/probabilit/modeling.py
@@ -755,7 +755,7 @@ class Constant(Node, OverloadMixin):
         return np.ones(size, dtype=type(self.value)) * self.value
 
     def get_parents(self):
-        return []  # A Constant does not have any parents
+        yield from []  # A Constant does not have any parents
 
     def __repr__(self):
         return f"{type(self).__name__}({self.value})"
@@ -833,7 +833,7 @@ class EmpiricalDistribution(AbstractDistribution):
         return np.quantile(a=self.data, q=q, **self.kwargs)
 
     def get_parents(self):
-        return []  # A EmpiricalDistribution does not have any parents
+        yield from []  # A EmpiricalDistribution does not have any parents
 
 
 class CumulativeDistribution(AbstractDistribution):
@@ -871,7 +871,7 @@ class CumulativeDistribution(AbstractDistribution):
         return np.interp(x=q, xp=self.q, fp=self.cumulatives)
 
     def get_parents(self):
-        return []
+        yield from []
 
 
 class DiscreteDistribution(AbstractDistribution):
@@ -916,7 +916,7 @@ class DiscreteDistribution(AbstractDistribution):
         return self.values[idx]
 
     def get_parents(self):
-        return []
+        yield from []
 
 
 # ========================================================


### PR DESCRIPTION
This was not as much code as I thought. Might be useful for debugging.

Current inspectio options for models:

- Print a Node, which will print everything - but becomes a very long expression
- Convert to networkx graph and draw it. Drawing must be implemented by user and lean on networkx, but the conversion will be done by probabilit
- `treeprint`
- Now also **treeprint**, which is similar to printing a Node but hopefully better