### PR TITLE
Add type annotations on input and return values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 dev = [
 "ruff",
 "pytest",
+"typing-extensions>=4.15.0",
 ]
 
 [project.urls]

--- a/src/probabilit/correlation.py
+++ b/src/probabilit/correlation.py
@@ -30,14 +30,19 @@ Induce correlations
 0.279652...
 """
 
+import abc
+import contextlib
+import dataclasses
+import itertools
+import os
+from collections.abc import Iterable, Iterator
+from typing import Any
+
 import numpy as np
 import scipy as sp
-import abc
-import dataclasses
+from typing_extensions import Self
 
-import contextlib
-import os
-import itertools
+from probabilit.types import Array1D, Array2D, CorrelationType
 
 # CVXPY prints error messages about incompatible ortools version during import.
 # Since we use the SCS solver and not GLOP/PDLP (which need ortools), these errors
@@ -56,7 +61,13 @@ class CorrelatorError(Exception):
     pass
 
 
-def nearest_correlation_matrix(matrix, *, weights=None, eps=1e-6, verbose=False):
+def nearest_correlation_matrix(
+    matrix: Array2D,
+    *,
+    weights: Array2D | None = None,
+    eps: float = 1e-6,
+    verbose: bool = False,
+) -> Array2D:
     """Returns the correlation matrix nearest to `matrix`, weighted elementwise
     by `weights`.
 
@@ -156,7 +167,7 @@ def nearest_correlation_matrix(matrix, *, weights=None, eps=1e-6, verbose=False)
     return X
 
 
-def _is_positive_definite(X):
+def _is_positive_definite(X: Array2D) -> bool:
     try:
         np.linalg.cholesky(X)
         return True
@@ -165,7 +176,7 @@ def _is_positive_definite(X):
 
 
 class Correlator(abc.ABC):
-    def set_target(self, correlation_matrix, cholesky=True):
+    def set_target(self, correlation_matrix: Array2D, cholesky: bool = True) -> Self:
         """Set target correlation matrix."""
         if not isinstance(correlation_matrix, np.ndarray):
             raise TypeError("Input argument `correlation_matrix` must be NumPy array.")
@@ -185,7 +196,7 @@ class Correlator(abc.ABC):
             self.P = np.linalg.cholesky(self.C)
         return self
 
-    def _validate_X(self, X, check_rows_cols=True):
+    def _validate_X(self, X: Array2D, check_rows_cols: bool = True) -> tuple[int, int]:
         """Validate array X of shape (observations, variables)."""
         if not (hasattr(self, "C")):
             raise CorrelatorError("User must call `set_target` first.")
@@ -244,11 +255,11 @@ class Cholesky(Correlator):
 
     """
 
-    def set_target(self, correlation_matrix):
+    def set_target(self, correlation_matrix: Array2D) -> Self:
         super().set_target(correlation_matrix)
         return self
 
-    def __call__(self, X):
+    def __call__(self, X: Array2D) -> Array2D:
         """Transform an input matrix X.
 
         Parameters
@@ -368,11 +379,11 @@ class ImanConover(Correlator):
     np.float64(0.592541)
     """
 
-    def set_target(self, correlation_matrix):
+    def set_target(self, correlation_matrix: Array2D) -> Self:
         super().set_target(correlation_matrix)
         return self
 
-    def __call__(self, X):
+    def __call__(self, X: Array2D) -> Array2D:
         """Transform an input matrix X.
 
         The output will have the same marginal distributions, but with
@@ -453,13 +464,13 @@ class SwapIndexGenerator:
     (array([7, 0, 4, 2]), array([3, 5, 1, 8]))
     """
 
-    def __init__(self, rng, n: int):
+    def __init__(self, rng: np.random.Generator, n: int):
         assert n >= 2
         self.rng = rng
         self.indices = np.arange(n)
         self.permutation = self.rng.permutation(self.indices)
 
-    def __call__(self, size: int):
+    def __call__(self, size: int) -> tuple[Array1D, Array1D]:
         assert size >= 1
 
         # Get 2 * size elements
@@ -482,12 +493,12 @@ class Permutation(Correlator):
     def __init__(
         self,
         *,
-        weights=None,
-        iterations=1000,
-        tol=0.01,
-        correlation_type="pearson",
-        random_state=None,
-        verbose=False,
+        weights: Array2D | None = None,
+        iterations: int = 1000,
+        tol: float = 0.01,
+        correlation_type: CorrelationType = "pearson",
+        random_state: np.random.Generator | int | None = None,
+        verbose: bool = False,
     ):
         """Create a Permutation instance, which induces correlations
         between variables in X by randomly shuffling rows within each column.
@@ -584,7 +595,12 @@ class Permutation(Correlator):
         self.verbose = verbose
         self.correlation_type = correlation_type
 
-    def set_target(self, correlation_matrix, *, weights=None):
+    def set_target(
+        self,
+        correlation_matrix: Array2D,
+        *,
+        weights: Array2D | None = None,
+    ) -> Self:
         """Set the target correlation matrix.
 
         Parameters
@@ -601,14 +617,14 @@ class Permutation(Correlator):
         self.triu_indices = np.triu_indices(self.C.shape[0], k=1)
         return self
 
-    def _error(self, observed, target):
+    def _error(self, observed: Array2D, target: Array2D) -> float:
         """Compute RMSE over upper triangular part of corr(X) - target."""
         idx = self.triu_indices  # Get upper triangular indices (ignore diag)
         weighted_residuals_sq = self.weights[idx] * (observed[idx] - target[idx]) ** 2.0
         return float(np.sqrt(np.sum(weighted_residuals_sq)))
 
     @staticmethod
-    def subiters(n, i):
+    def subiters(n: int, i: int) -> int:
         """Number of sub-iterations (swaps) per iteration."""
         # Use longer swap lengths in early iterations. The last half
         # of the iterations will use 1 sub-iteration. The second half of the
@@ -622,7 +638,7 @@ class Permutation(Correlator):
         C = np.log2(n) + 1
         return int(np.ceil(C ** (1 - (2 * i / n))))
 
-    def __call__(self, X):
+    def __call__(self, X: Array2D) -> Array2D:
         """Cycle through through columns (variables), and for each
         column it swaps random rows (observations). If the result
         leads to a smaller error (correlation closer to target), then it is
@@ -652,7 +668,9 @@ class Permutation(Correlator):
                 f"Running permutation correlator for {self.iters if self.iters else 'inf'} iterations."
             )
 
-        def product(iterations_gen, variables_gen):
+        def product(
+            iterations_gen: Iterable[int], variables_gen: Iterable[int]
+        ) -> Iterator[tuple[int, int]]:
             # itertools.product only works for finite inputs, so we need this
             for i in iterations_gen:
                 for j in variables_gen:
@@ -709,7 +727,7 @@ class Permutation(Correlator):
         return corr_mat.X  # The permuted data stored in CorrelationMatrix
 
 
-def decorrelate(X, remove_variance=True):
+def decorrelate(X: Array2D, remove_variance: bool = True) -> Array2D:
     """Removes correlations or covariance from data X.
 
     Examples
@@ -823,7 +841,12 @@ class CorrelationMatrix:
            [ 0.325, -0.6  , -0.151,  1.   ]])
     """
 
-    def __init__(self, X, correlation_type="pearson", check=True):
+    def __init__(
+        self,
+        X: Array2D,
+        correlation_type: CorrelationType = "pearson",
+        check: bool = True,
+    ):
         valid_corrs = ("pearson", "spearman")
         assert correlation_type in valid_corrs
         assert X.ndim == 2
@@ -858,13 +881,18 @@ class CorrelationMatrix:
             :, None
         ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.corr_mat)
 
-    def __getitem__(self, *args, **kwargs):
+    def __getitem__(self, *args: Any, **kwargs: Any) -> float:
         return self.corr_mat.__getitem__(*args, **kwargs)
 
-    def commit(self, col, i, j):
+    def commit(
+        self,
+        col: int,
+        i: int | list[int],
+        j: int | list[int],
+    ) -> Self:
         """Commit a swap, storing new data and new correlation matrix."""
 
         # Compute everything we need to update internal state
@@ -885,7 +913,12 @@ class CorrelationMatrix:
             self.X[i, col], self.X[j, col] = self.X[j, col], self.X[i, col]
         return self
 
-    def _delta_numerator(self, col, i, j):
+    def _delta_numerator(
+        self,
+        col: int,
+        i: int | list[int],
+        j: int | list[int],
+    ) -> Array1D:
         """Compute the delta in the numerator when swapping."""
         if self.check:
             assert isinstance(col, int)
@@ -912,14 +945,24 @@ class CorrelationMatrix:
         delta_numerator[col] = 0.0
         return delta_numerator
 
-    def delta_column(self, col, i, j):
+    def delta_column(
+        self,
+        col: int,
+        i: int | list[int],
+        j: int | list[int],
+    ) -> Array1D:
         """Returns the change in the column `col` in the correlation matrix
         when rows i and j are swapped. To save a change, use `.commit()`."""
 
         diff = self._delta_numerator(col, i, j)
         return diff / (self.m * self.denominator * self.denominator[col])
 
-    def update_column(self, col, i, j):
+    def update_column(
+        self,
+        col: int,
+        i: int | list[int],
+        j: int | list[int],
+    ) -> Array1D:
         """Returns the new value of column `col` in the correlation matrix
         when rows i and j are swapped. To save a change, use `.commit()`."""
 
@@ -953,16 +996,21 @@ class Composite(Correlator):
     array([-0.23,  1.  , -0.25, -0.27, -0.88, -0.24])
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         self.iman_conover_correlator = ImanConover()
         self.permutation_correlator = Permutation(*args, **kwargs)
 
-    def set_target(self, correlation_matrix, *, weights=None):
+    def set_target(
+        self,
+        correlation_matrix: Array2D,
+        *,
+        weights: Array2D | None = None,
+    ) -> Self:
         self.iman_conover_correlator.set_target(correlation_matrix)
         self.permutation_correlator.set_target(correlation_matrix, weights=weights)
         return self
 
-    def __call__(self, X):
+    def __call__(self, X: Array2D) -> Array2D:
         try:
             # First run ImanConover to get a good starting point
             X_ic = self.iman_conover_correlator(X)
@@ -971,14 +1019,13 @@ class Composite(Correlator):
                 X_ic = X
             else:
                 raise  # re-raise if it's a different ValueError
-
         # Then run Permutation
         return self.permutation_correlator(X_ic)
 
 
 if __name__ == "__main__":
-    import pytest
     import matplotlib.pyplot as plt
+    import pytest
 
     pytest.main(args=[__file__, "--doctest-modules", "-v", "--capture=sys"])
 

--- a/src/probabilit/distributions.py
+++ b/src/probabilit/distributions.py
@@ -41,23 +41,27 @@ the PERT distribution, then convert it to a Beta parametrization for scipy:
 (51.32..., 248.67...)
 """
 
-import numpy as np
 import warnings
+
+import numpy as np
 import scipy as sp
-from probabilit.modeling import Distribution, Log, Exp, Sign
+
+from probabilit.modeling import Distribution, Exp, Log, Sign
 
 
-def Uniform(minimum=0, maximum=1):
+def Uniform(minimum: float = 0, maximum: float = 1) -> Distribution:
     """Uniform distribution on [minimum, maximum)."""
     return Distribution("uniform", loc=minimum, scale=maximum - minimum)
 
 
-def Normal(mean=0, std=1):
+def Normal(mean: float = 0, std: float = 1) -> Distribution:
     """Normal distribution parametrized by mean (loc) and std (scale)."""
     return Distribution("norm", loc=mean, scale=std)
 
 
-def TruncatedNormal(mean, std, *, low=-np.inf, high=np.inf):
+def TruncatedNormal(
+    mean: float, std: float, *, low: float = -np.inf, high: float = np.inf
+) -> Distribution:
     """A truncated Normal distribution parametrized by mean (loc) and
     std (scale) defined on [low, high).
 
@@ -73,7 +77,7 @@ def TruncatedNormal(mean, std, *, low=-np.inf, high=np.inf):
 
 
 class Lognormal(Distribution):
-    def __init__(self, mean, std):
+    def __init__(self, mean: float, std: float):
         """
         A Lognormal distribution with mean and std corresponding directly
         to the expected value and standard deviation of the resulting lognormal.
@@ -102,7 +106,7 @@ class Lognormal(Distribution):
         super().__init__(distr="lognorm", s=sigma, scale=Exp(mu))
 
     @classmethod
-    def from_log_params(cls, mu, sigma):
+    def from_log_params(cls, mu: Distribution, sigma: float) -> Distribution:
         """
         Create a lognormal distribution from log-space parameters.
         Parameters correspond to the mean and standard deviation of the
@@ -118,7 +122,15 @@ class Lognormal(Distribution):
         return Distribution("lognorm", s=sigma, scale=Exp(mu))
 
 
-def PERT(low, mode, high, *, low_perc=0.0, high_perc=1.0, gamma=4.0):
+def PERT(
+    low: float,
+    mode: float,
+    high: float,
+    *,
+    low_perc: float = 0.0,
+    high_perc: float = 1.0,
+    gamma: float = 4.0,
+) -> "Distribution":
     """Returns a Beta distribution, parameterized by the PERT parameters.
     Finds an optimal parametrization given (low, mode, high) and
     returns Distribution("beta", a=..., b=..., loc=..., scale=...).
@@ -157,7 +169,14 @@ def PERT(low, mode, high, *, low_perc=0.0, high_perc=1.0, gamma=4.0):
     return Distribution("beta", a=a, b=b, loc=loc, scale=scale)
 
 
-def Triangular(low, mode, high, *, low_perc=0.0, high_perc=1.0):
+def Triangular(
+    low: float,
+    mode: float,
+    high: float,
+    *,
+    low_perc: float = 0.0,
+    high_perc: float = 1.0,
+) -> Distribution:
     """Find optimal scipy parametrization given (low, mode, high) and
     return Distribution("triang", loc=..., scale=..., c=...).
 
@@ -195,7 +214,14 @@ def Triangular(low, mode, high, *, low_perc=0.0, high_perc=1.0):
     return Distribution("triang", loc=loc, scale=scale, c=c)
 
 
-def _fit_triangular_distribution(low, mode, high, *, low_perc=0.10, high_perc=0.90):
+def _fit_triangular_distribution(
+    low: float,
+    mode: float,
+    high: float,
+    *,
+    low_perc: float = 0.10,
+    high_perc: float = 0.90,
+) -> tuple[float, float, float]:
     """Returns a tuple (loc, scale, c) to be used with scipy.
 
     Description
@@ -233,15 +259,15 @@ def _fit_triangular_distribution(low, mode, high, *, low_perc=0.10, high_perc=0.
     a = 2 / (high - low)
     b = 1 - (2 * high) / (high - low)
 
-    def scaler(x):
+    def scaler(x: float) -> float:
         return a * x + b
 
-    def inv_scaler(y):
+    def inv_scaler(y: float) -> float:
         return (y - b) / a
 
     low, mode, high = scaler(low), scaler(mode), scaler(high)
 
-    def rmse_minimum_maximum(parameters):
+    def rmse_minimum_maximum(parameters: tuple[float, float]) -> float:
         """Given (minimum, maximum) of a distribution, create the distribution,
         evaluate the inverse-CDF (PPF) and see how close (low, high) is to the
         desired values of (low, high).
@@ -305,7 +331,9 @@ def _fit_triangular_distribution(low, mode, high, *, low_perc=0.10, high_perc=0.
     return float((loc)), float((scale)), float(c)
 
 
-def _pert_to_beta(minimum, mode, maximum, *, gamma=4.0):
+def _pert_to_beta(
+    minimum: float, mode: float, maximum: float, *, gamma: float = 4.0
+) -> tuple[float, float, float, float]:
     """Convert the PERT parametrization to a beta distribution.
 
     Returns (a, b, loc, scale).
@@ -337,7 +365,15 @@ def _pert_to_beta(minimum, mode, maximum, *, gamma=4.0):
     return a, b, loc, scale
 
 
-def _fit_pert_distribution(low, mode, high, *, low_perc=0.10, high_perc=0.90, gamma=4):
+def _fit_pert_distribution(
+    low: float,
+    mode: float,
+    high: float,
+    *,
+    low_perc: float = 0.10,
+    high_perc: float = 0.90,
+    gamma: float = 4,
+) -> tuple[float, float]:
     """
     Returns the maximum and the minimum of a PERT distribution with
     percentiles corresponding to the inputs.
@@ -353,15 +389,15 @@ def _fit_pert_distribution(low, mode, high, *, low_perc=0.10, high_perc=0.90, ga
     a = 2 / (high - low)
     b = 1 - (2 * high) / (high - low)
 
-    def scaler(x):
+    def scaler(x: float) -> float:
         return a * x + b
 
-    def inv_scaler(y):
+    def inv_scaler(y: float) -> float:
         return (y - b) / a
 
     low, mode, high = scaler(low), scaler(mode), scaler(high)
 
-    def rmse_minimum_maximum(parameters):
+    def rmse_minimum_maximum(parameters: tuple[float, float]) -> float:
         """Given (minimum, maximum) of a distribution, create the distribution,
         evaluate the inverse-CDF (PPF) and see how close (low, high) is to the
         desired values of (low, high).

--- a/src/probabilit/garbage_collector.py
+++ b/src/probabilit/garbage_collector.py
@@ -1,5 +1,8 @@
 import collections
-from collections.abc import Collection
+from collections.abc import Collection, Iterable
+from typing import Any
+
+from typing_extensions import Self
 
 
 class GarbageCollector:
@@ -15,13 +18,13 @@ class GarbageCollector:
         empty list means all nodes except the sink will be garbage collected.
     """
 
-    def __init__(self, strategy=None):
+    def __init__(self, strategy: Iterable[Any] | None = None):
         if not (strategy is None or isinstance(strategy, Collection)):
             raise TypeError(f"`strategy` must be None or a collection, got: {strategy}")
 
         self.strategy = strategy
 
-    def set_sink(self, sink):
+    def set_sink(self, sink: Any) -> Self:
         """Set the sink node, whose samples will always be kept."""
         self.sink = sink
 
@@ -39,7 +42,7 @@ class GarbageCollector:
 
         return self
 
-    def decrement_and_delete(self, node):
+    def decrement_and_delete(self, node: Any) -> list[Any]:
         """Decrement the reference counter (number of unsampled children for
         each parent) and delete `.samples_` if the reference count is zero.
 

--- a/src/probabilit/inspection.py
+++ b/src/probabilit/inspection.py
@@ -5,14 +5,24 @@ Inspection
 Inspection of results, plotting, tables, exporting, etc.
 """
 
-import seaborn
-import pandas as pd
-from probabilit.modeling import NoOp, Distribution, Transform
-import numpy as np
 from numbers import Number
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import seaborn
+from seaborn.axisgrid import PairGrid
+
+from probabilit.modeling import Distribution, Node, NoOp, Transform
+from probabilit.types import Array2D
 
 
-def plot(*variables, corr=None, sample_kwargs=None, **kwargs):
+def plot(
+    *variables: Distribution,
+    corr: Array2D | None = None,
+    sample_kwargs: Any = None,
+    **kwargs: Any,
+) -> PairGrid:
     """Utility function for quick plotting of one or several variables.
 
     Examples
@@ -62,7 +72,7 @@ def plot(*variables, corr=None, sample_kwargs=None, **kwargs):
     return seaborn.pairplot(df, **kwargs)
 
 
-def treeprint(node):
+def treeprint(node: Node) -> None:
     """Print a computational graph in a tree-like fashion.
 
     Examples
@@ -82,7 +92,12 @@ def treeprint(node):
     """
     elbow, pipe, tee, blank = "└──", "│  ", "├──", "   "
 
-    def _treeprint(node, last=True, header="", root=False):
+    def _treeprint(
+        node: Node,
+        last: bool = True,
+        header: str = "",
+        root: bool = False,
+    ) -> None:
         # Recursive version
         output = type(node).__name__ if isinstance(node, Transform) else str(node)
         print(header + ("" if root else (elbow if last else tee)) + output)

--- a/src/probabilit/modeling.py
+++ b/src/probabilit/modeling.py
@@ -270,37 +270,53 @@ simulation model, or read and write files, etc.
 
 """
 
-import operator
-import functools
-import numpy as np
-import scipy as sp
-import numbers
-from scipy import stats
 import abc
+import copy
+import functools
 import itertools
+import numbers
+import operator
+import typing
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from typing import Generic, TypeVar, overload
+
 import networkx as nx
+import numpy as np
+import numpy.typing as npt
+import scipy as sp
+from scipy import stats
 from scipy._lib._util import check_random_state
+from typing_extensions import Self
+
 from probabilit.correlation import (
-    nearest_correlation_matrix,
-    ImanConover,
     Cholesky,
     Composite,
+    Correlator,
+    ImanConover,
     Permutation,
+    nearest_correlation_matrix,
+)
+from probabilit.garbage_collector import GarbageCollector
+from probabilit.types import (
+    Array1D,
+    Array2D,
+    CorrelatorType,
+    DistributionType,
+    SamplingMethodType,
 )
 from probabilit.utils import zip_args
-from probabilit.garbage_collector import GarbageCollector
-import copy
-
 
 # =============================================================================
 # FUNCTIONS
 # =============================================================================
 
+T = TypeVar("T", bound=numbers.Number)
 
-def python_to_prob(argument):
+
+def python_to_prob(argument: T | "Node") -> "Constant[T] | Node":
     """Convert basic Python types to probabilit types."""
     if isinstance(argument, numbers.Number):
-        return Constant(argument)
+        return Constant[T](argument)
     elif isinstance(argument, Node):
         return argument
     else:
@@ -370,20 +386,20 @@ class Node(abc.ABC):
 
     id_iter = itertools.count()  # Every node gets a unique ID
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._id = next(self.id_iter)
         self._correlations = []
 
-    def __eq__(self, other):
+    def __eq__(self, other: "Node") -> bool:
         if not isinstance(other, Node):
             return NotImplemented
         # Needed for set() to work on Node. Equality in models must use Equal()
         return self._id == other._id
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return self._id
 
-    def copy(self):
+    def copy(self) -> Self:
         """Copy the Node, including the entire graph above it.
 
         Examples
@@ -401,7 +417,13 @@ class Node(abc.ABC):
         # Map from ID to new object copy
         id_to_new = dict()
 
-        def update(item):
+        @overload
+        def update(item: numbers.Number) -> numbers.Number: ...
+
+        @overload
+        def update(item: Node) -> Node: ...
+
+        def update(item: Node | numbers.Number) -> Node | numbers.Number:
             """Given an item, use the ID to map to new object copy."""
             if isinstance(item, Node):
                 return id_to_new[item._id]
@@ -436,7 +458,7 @@ class Node(abc.ABC):
 
         return id_to_new[self._id]
 
-    def nodes(self):
+    def nodes(self) -> Iterator[Self]:
         """Yields `self` and all ancestors using depth-first-search.
 
         Examples
@@ -455,7 +477,7 @@ class Node(abc.ABC):
             yield (node := queue.pop())
             queue.extend(node.get_parents())
 
-    def num_distribution_nodes(self):
+    def num_distribution_nodes(self) -> int:
         """Number of unique ancestor nodes that are distribution nodes."""
         return sum(
             1 for node in set(self.nodes()) if isinstance(node, AbstractDistribution)
@@ -463,13 +485,13 @@ class Node(abc.ABC):
 
     def sample(
         self,
-        size=1,
+        size: int = 1,
         *,
-        random_state=None,
-        method=None,
-        correlator="composite",
-        gc_strategy=None,
-    ):
+        random_state: np.random.Generator | int | None = None,
+        method: SamplingMethodType | None = None,
+        correlator: Correlator | CorrelatorType = "composite",
+        gc_strategy: list[Self] | None = None,
+    ) -> Array1D:
         """Sample the current node and assign attribute `samples_` to nodes.
 
         Parameters
@@ -559,8 +581,13 @@ class Node(abc.ABC):
         )
 
     def sample_from_quantiles(
-        self, quantiles, *, correlator="composite", gc_strategy=None, random_state=None
-    ):
+        self,
+        quantiles: Array2D,
+        *,
+        correlator: Correlator | CorrelatorType = "composite",
+        gc_strategy: list[Self] | None = None,
+        random_state: np.random.Generator | int | None = None,
+    ) -> Array1D:
         """Use samples from an array of quantiles in [0, 1] to sample all
         distributions. The array must have shape (dimensionality, num_samples)."""
         assert nx.is_directed_acyclic_graph(self.to_graph())
@@ -733,7 +760,7 @@ class Node(abc.ABC):
         topo_sample(self.to_graph(), gc=gc, garbage_collected=garbage_collected)
         return self.samples_
 
-    def _is_initial_sampling_node(self):
+    def _is_initial_sampling_node(self) -> bool:
         """A node is an initial sample node iff:
         (1) It is a Distribution
         (2) None of its ancestors are Distributions (all are Constant/Transform)"""
@@ -745,7 +772,7 @@ class Node(abc.ABC):
         )
         return is_distribution and not ancestors_distr
 
-    def correlate(self, *variables, corr_mat):
+    def correlate(self, *variables: "Distribution", corr_mat: Array2D) -> Self:
         """Store correlations on variables.
 
         When `.correlate(*variables)` is called on a node, the variables must
@@ -787,7 +814,7 @@ class Node(abc.ABC):
         self._correlations.append((list(variables), np.copy(corr_mat)))
         return self
 
-    def to_graph(self):
+    def to_graph(self) -> nx.MultiDiGraph:
         """Convert the computational graph to a networkx MultiDiGraph."""
         nodes = list(self.nodes())
 
@@ -810,64 +837,64 @@ class Node(abc.ABC):
 class OverloadMixin:
     """Overloads dunder (double underscore) methods for easier modeling."""
 
-    def __add__(self, other):
+    def __add__(self, other: typing.Any) -> "Add":
         return Add(self, other)
 
-    def __radd__(self, other):
+    def __radd__(self, other: typing.Any) -> "Add":
         return Add(self, other)
 
-    def __mul__(self, other):
+    def __mul__(self, other: typing.Any) -> "Multiply":
         return Multiply(self, other)
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: typing.Any) -> "Multiply":
         return Multiply(self, other)
 
-    def __floordiv__(self, other):
+    def __floordiv__(self, other: typing.Any) -> "FloorDivide":
         return FloorDivide(self, other)
 
-    def __rfloordiv__(self, other):
+    def __rfloordiv__(self, other: typing.Any) -> "FloorDivide":
         return FloorDivide(other, self)
 
-    def __truediv__(self, other):
+    def __truediv__(self, other: typing.Any) -> "Divide":
         return Divide(self, other)
 
-    def __rtruediv__(self, other):
+    def __rtruediv__(self, other: typing.Any) -> "Divide":
         return Divide(other, self)
 
-    def __mod__(self, other):
+    def __mod__(self, other: typing.Any) -> "Mod":
         return Mod(self, other)
 
-    def __rmod__(self, other):
+    def __rmod__(self, other: typing.Any) -> "Mod":
         return Mod(other, self)
 
-    def __sub__(self, other):
+    def __sub__(self, other: typing.Any) -> "Subtract":
         return Subtract(self, other)
 
-    def __rsub__(self, other):
+    def __rsub__(self, other: typing.Any) -> "Subtract":
         return Subtract(other, self)
 
-    def __pow__(self, other):
+    def __pow__(self, other: typing.Any) -> "Power":
         return Power(self, other)
 
-    def __rpow__(self, other):
+    def __rpow__(self, other: typing.Any) -> "Power":
         return Power(other, self)
 
-    def __neg__(self):
+    def __neg__(self) -> "Negate":
         return Negate(self)
 
-    def __abs__(self):
+    def __abs__(self) -> "Abs":
         return Abs(self)
 
-    def __lt__(self, other):
+    def __lt__(self, other: typing.Any) -> "LessThan":
         return LessThan(self, other)
 
-    def __le__(self, other):
+    def __le__(self, other: typing.Any) -> "LessThanOrEqual":
         return LessThanOrEqual(self, other)
 
-    def __gt__(self, other):
+    def __gt__(self, other: typing.Any) -> "GreaterThan":
         return GreaterThan(self, other)
 
-    def __ge__(self, other):
+    def __ge__(self, other: typing.Any) -> "GreaterThanOrEqual":
         return GreaterThanOrEqual(self, other)
 
     # TODO: __eq__ (==) and __ne__ (!=) are not implemented here,
@@ -875,7 +902,7 @@ class OverloadMixin:
     # both equality checks and __hash__.
 
 
-class Constant(Node, OverloadMixin):
+class Constant(Node, OverloadMixin, Generic[T]):
     """A constant is a number or a string. If the value is a string, sampling returns an array of the string value.
 
     Examples
@@ -888,19 +915,25 @@ class Constant(Node, OverloadMixin):
 
     is_source_node = True  # A Constant is always a source node
 
-    def __init__(self, value):
-        self.value = value.value if isinstance(value, Constant) else value
+    def __init__(self, value: T | "Constant[T]"):
+        self.value: T = value.value if isinstance(value, Constant) else value
         super().__init__()
 
-    def _sample(self, size=None):
+    @overload
+    def _sample(self, size: int) -> npt.NDArray[typing.Any]: ...
+
+    @overload
+    def _sample(self, size: None = ...) -> T: ...
+
+    def _sample(self, size: int | None = None) -> T | npt.NDArray[typing.Any]:
         if size is None:
             return self.value
         return np.array([self.value] * size)
 
-    def get_parents(self):
+    def get_parents(self) -> Iterator[None]:
         yield from []  # A Constant does not have any parents
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{type(self).__name__}({self.value})"
 
 
@@ -911,13 +944,18 @@ class AbstractDistribution(Node, OverloadMixin, abc.ABC):
 class Distribution(AbstractDistribution):
     """A distribution is a sampling node with or without ancestors."""
 
-    def __init__(self, distr, *args, **kwargs):
+    def __init__(
+        self,
+        distr: DistributionType,
+        *args: Node | numbers.Number,
+        **kwargs: typing.Any,
+    ):
         self.distr = distr
         self.args = args
         self.kwargs = kwargs
         super().__init__()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         args = ", ".join(repr(arg) for arg in self.args)
         kwargs = ", ".join(f"{k}={repr(v)}" for (k, v) in self.kwargs.items())
         out = f'{type(self).__name__}("{self.distr}"'
@@ -927,7 +965,7 @@ class Distribution(AbstractDistribution):
             out += f", {kwargs}"
         return out + ")"
 
-    def to_scipy(self):
+    def to_scipy(self) -> typing.Any:
         if not self._is_initial_sampling_node():
             raise Exception(
                 "To convert a distribution to a scipy object, "
@@ -941,7 +979,7 @@ class Distribution(AbstractDistribution):
         except AttributeError:
             raise AttributeError(f"{self.distr!r} is not a valid scipy distribution")
 
-        def to_number(arg):
+        def to_number(arg: Node | numbers.Number) -> numbers.Number:
             """Unpack argument to a number in case parents are Constant/Transform"""
             return arg.sample(1)[0] if isinstance(arg, Node) else arg
 
@@ -950,8 +988,8 @@ class Distribution(AbstractDistribution):
 
         return distribution(*args, **kwargs)
 
-    def _sample(self, q):
-        def unpack(arg):
+    def _sample(self, q: Sequence[float]) -> Array1D:
+        def unpack(arg: Node | numbers.Number) -> Array1D | numbers.Number:
             """Unpack distribution arguments (parents) to arrays if Node."""
             return arg.samples_ if isinstance(arg, Node) else arg
 
@@ -969,14 +1007,14 @@ class Distribution(AbstractDistribution):
             seed = int(q[0] * 2**20)  # Seed based on q
             return distribution(*args, **kwargs).rvs(size=len(q), random_state=seed)
 
-    def get_parents(self):
+    def get_parents(self) -> Iterator[Node]:
         # A distribution only has parents if it has parameters that are Nodes
         for arg in self.args + tuple(self.kwargs.values()):
             if isinstance(arg, Node):
                 yield arg
 
     @property
-    def is_source_node(self):
+    def is_source_node(self) -> bool:
         return list(self.get_parents()) == []
 
 
@@ -987,18 +1025,18 @@ class EmpiricalDistribution(AbstractDistribution):
 
     is_source_node = True
 
-    def __init__(self, data, **kwargs):
+    def __init__(self, data: Iterable[float], **kwargs: typing.Any):
         self.data = np.array(data)
         self.kwargs = kwargs
         super().__init__()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{type(self).__name__}()"
 
-    def _sample(self, q):
+    def _sample(self, q: float) -> float:
         return np.quantile(a=self.data, q=q, **self.kwargs)
 
-    def get_parents(self):
+    def get_parents(self) -> Iterator[None]:
         yield from []  # A EmpiricalDistribution does not have any parents
 
 
@@ -1018,7 +1056,7 @@ class CumulativeDistribution(AbstractDistribution):
 
     is_source_node = True
 
-    def __init__(self, quantiles, cumulatives):
+    def __init__(self, quantiles: Sequence[float], cumulatives: Sequence[float]):
         self.q = np.array(quantiles)
         self.cumulatives = np.array(cumulatives)
         if not np.all(np.diff(self.q) > 0):
@@ -1029,14 +1067,14 @@ class CumulativeDistribution(AbstractDistribution):
             raise ValueError("Lowest quantile must be 0 and highest must be 1.")
         super().__init__()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{type(self).__name__}(quantiles={repr(self.q)}, cumulatives={repr(self.cumulatives)})"
 
-    def _sample(self, q):
+    def _sample(self, q: float) -> float:
         # Inverse CDF sampling
         return np.interp(x=q, xp=self.q, fp=self.cumulatives)
 
-    def get_parents(self):
+    def get_parents(self) -> Iterator[None]:
         yield from []
 
 
@@ -1055,7 +1093,11 @@ class DiscreteDistribution(AbstractDistribution):
 
     is_source_node = True
 
-    def __init__(self, values, probabilities=None):
+    def __init__(
+        self,
+        values: Sequence[float],
+        probabilities: Sequence[float] | None = None,
+    ):
         self.values = np.array(values)
         if probabilities is None:
             self.probabilities = np.ones(len(self.values), dtype=float)
@@ -1073,15 +1115,15 @@ class DiscreteDistribution(AbstractDistribution):
             raise ValueError("Probabilities are not non-negative.")
         super().__init__()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{type(self).__name__}(values={repr(self.values)}, probabilities={repr(self.probabilities)})"
 
-    def _sample(self, q):
+    def _sample(self, q: float) -> float:
         cumulative_probabilities = np.cumsum(self.probabilities)
         idx = np.searchsorted(cumulative_probabilities, v=q, side="right")
         return self.values[idx]
 
-    def get_parents(self):
+    def get_parents(self) -> Iterator[None]:
         yield from []
 
 
@@ -1093,7 +1135,7 @@ class Transform(Node, OverloadMixin, abc.ABC):
 
     is_source_node = False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         parents = ", ".join(repr(parent) for parent in self.get_parents())
         return f"{type(self).__name__}({parents})"
 
@@ -1105,15 +1147,15 @@ class VariadicTransform(Transform):
 
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args: numbers.Number | Node):
         self.parents = tuple(python_to_prob(arg) for arg in args)
         super().__init__()
 
-    def _sample(self, size=None):
+    def _sample(self, size: int | None = None) -> Array1D:
         samples = (parent.samples_ for parent in self.parents)
         return functools.reduce(self.op, samples)
 
-    def get_parents(self):
+    def get_parents(self) -> Iterator[Node]:
         yield from self.parents
 
 
@@ -1142,7 +1184,7 @@ class Any(VariadicTransform):
 
 
 class Avg(VariadicTransform):
-    def _sample(self, size=None):
+    def _sample(self, size: int | None = None) -> Array1D:
         # Avg(a, Avg(b, c)) !=  Avg(Avg(a, b), c), so we override _sample()
         samples = tuple(parent.samples_ for parent in self.parents)
         return np.average(np.vstack(samples), axis=0)
@@ -1151,22 +1193,22 @@ class Avg(VariadicTransform):
 class NoOp(VariadicTransform):
     """Sample all ancestor variables, but do nothing else."""
 
-    def _sample(self, size=None):
+    def _sample(self, size: int | None = None) -> None:
         tuple(parent.samples_ for parent in self.parents)
 
 
 class BinaryTransform(Transform):
     """Class for binary transforms, such as Divide, Power, Subtract, etc."""
 
-    def __init__(self, *args):
+    def __init__(self, *args: Node | numbers.Number):
         self.parents = tuple(python_to_prob(arg) for arg in args)
         super().__init__()
 
-    def _sample(self, size=None):
+    def _sample(self, size: int | None = None) -> Array1D:
         samples = (parent.samples_ for parent in self.parents)
         return self.op(*samples)
 
-    def get_parents(self):
+    def get_parents(self) -> Iterator[Node]:
         yield from self.parents
 
 
@@ -1222,14 +1264,14 @@ class UnaryTransform(Transform):
     """Class for unary tranforms, i.e. functions that take one argument, such
     as Abs(), Exp(), Log()."""
 
-    def __init__(self, arg):
+    def __init__(self, arg: numbers.Number | Node):
         self.parent = python_to_prob(arg)
         super().__init__()
 
-    def _sample(self, size=None):
+    def _sample(self, size: int | None = None) -> Array1D:
         return self.op(self.parent.samples_)
 
-    def get_parents(self):
+    def get_parents(self) -> Iterator[Node]:
         yield self.parent
 
 
@@ -1331,14 +1373,19 @@ class ScalarFunctionTransform(Transform):
     """A general-purpose transform using a function that takes scalar arguments
     and returns a scalar result."""
 
-    def __init__(self, func, args, kwargs):
+    def __init__(
+        self,
+        func: Callable[..., typing.Any],
+        args: tuple[Node, ...],
+        kwargs: Mapping[str, typing.Any],
+    ):
         self.func = func
         self.args = args
         self.kwargs = kwargs
         super().__init__()
 
-    def _sample(self, size=None):
-        def unpack(arg):
+    def _sample(self, size: int | None = None) -> Array1D:
+        def unpack(arg: Node | numbers.Number) -> Array1D | Iterator[numbers.Number]:
             return arg.samples_ if isinstance(arg, Node) else itertools.repeat(arg)
 
         # Sample arguments
@@ -1352,19 +1399,23 @@ class ScalarFunctionTransform(Transform):
             ]
         )
 
-    def get_parents(self):
+    def get_parents(self) -> Iterator[Node]:
         # A function has have parents if its arguments are Nodes
         for arg in self.args + tuple(self.kwargs.values()):
             if isinstance(arg, Node):
                 yield arg
 
 
-def scalar_transform(func):
+def scalar_transform(
+    func: Callable[..., typing.Any],
+) -> Callable[..., ScalarFunctionTransform]:
     """Transform a function, so that when it is called it is converted to
     a ScalarFunctionTransform."""
 
     @functools.wraps(func)
-    def transformed_function(*args, **kwargs):
+    def transformed_function(
+        *args: Node, **kwargs: typing.Any
+    ) -> ScalarFunctionTransform:
         return ScalarFunctionTransform(func, args, kwargs)
 
     return transformed_function
@@ -1385,23 +1436,27 @@ class MarginalDistribution(Transform):
 
     is_source_node = False
 
-    def __init__(self, distr, d):
+    def __init__(self, distr: Distribution, d: int):
         self.distr = distr
         self.d = d
         super().__init__()
 
-    def _sample(self):
+    def _sample(self) -> Array2D:
         # Simply slice the parent
         return np.atleast_2d(self.distr.samples_)[:, self.d]
 
-    def get_parents(self):
+    def get_parents(self) -> Iterator[Distribution]:
         yield self.distr
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{type(self).__name__}({self.distr}, d={self.d})"
 
 
-def MultivariateDistribution(distr, *args, **kwargs):
+def MultivariateDistribution(
+    distr: DistributionType,
+    *args: Node | numbers.Number,
+    **kwargs: typing.Any,
+) -> Iterator[MarginalDistribution]:
     """Factory function that yields marginal distributions.
 
     Examples

--- a/src/probabilit/types.py
+++ b/src/probabilit/types.py
@@ -1,0 +1,18 @@
+from typing import Literal
+
+import numpy as np
+
+Array1D = np.ndarray[tuple[int], np.dtype[np.float64]]
+Array2D = np.ndarray[tuple[int, int], np.dtype[np.float64]]
+CorrelationType = Literal["pearson", "spearman"]
+CorrelatorType = Literal["cholesky", "imanconover", "permutation", "composite"]
+SamplingMethodType = Literal["lhs", "halton", "sobol"]
+DistributionType = Literal[
+    "uniform",
+    "norm",
+    "truncnorm",
+    "lognorm",
+    "beta",
+    "triang",
+    "dirichlet",
+]

--- a/src/probabilit/utils.py
+++ b/src/probabilit/utils.py
@@ -1,9 +1,19 @@
 import itertools
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 import scipy as sp
 
+from probabilit.types import Array2D
 
-def adjust_minmax_quantiles(quantiles, cumulatives, expected):
+
+def adjust_minmax_quantiles(
+    quantiles: Iterable[float],
+    cumulatives: Iterable[float],
+    expected: float,
+) -> Array2D:
     """Adjust minimum and maximum in `quantiles` so we hit expected value.
 
     Examples
@@ -26,13 +36,20 @@ def adjust_minmax_quantiles(quantiles, cumulatives, expected):
     assert np.isclose(np.min(quantiles), 0)
     assert np.isclose(np.max(quantiles), 1)
 
-    def empirical_mean(quantiles, cumulatives):
+    def empirical_mean(
+        quantiles: npt.NDArray[Any],
+        cumulatives: npt.NDArray[Any],
+    ) -> float:
         """Compute the expected value of a histogram."""
         return sp.stats.rv_histogram(
             (np.diff(quantiles), cumulatives), density=False
         ).mean()
 
-    def transform(low_scale, high_scale, cumulatives):
+    def transform(
+        low_scale: float,
+        high_scale: float,
+        cumulatives: npt.NDArray[Any],
+    ) -> tuple[float, float]:
         """Return new low and high values in the cumulatives."""
         cumulatives = cumulatives.copy()
         q1, q2 = cumulatives[:2]
@@ -41,7 +58,12 @@ def adjust_minmax_quantiles(quantiles, cumulatives, expected):
         low = min(q2 - np.exp(low_scale) * (q2 - q1), q2 - 1e-6)
         return (low, high)
 
-    def objective(params, quantiles, cumulatives, expected):
+    def objective(
+        params: tuple[float, float],
+        quantiles: npt.NDArray[Any],
+        cumulatives: npt.NDArray[Any],
+        expected: float,
+    ) -> float:
         """Objective function to minimize."""
         low_scale, high_scale = params
 
@@ -70,7 +92,10 @@ def adjust_minmax_quantiles(quantiles, cumulatives, expected):
     return cumulatives
 
 
-def zip_args(args, kwargs):
+def zip_args(
+    args: Iterable[Any],
+    kwargs: Mapping[str, Any],
+) -> Iterator[tuple[Any, dict[str, Any]]]:
     """Zip argument and keyword arguments for repeated function calls.
 
     Examples


### PR DESCRIPTION
Closes #72 

This PR adds type annotations for all input arguments and return values for all functions and methods.

I might not have gotten the correct types in all functions, so please correct me if there is anything wrong. There is currently limited typing capabilities in numpy out of the box, but saying if it is a 1d array (`np.ndarray[tuple[int], np.float64]`) or 2D-array (`np.ndarray[tuple[int, int], np.float64]`) is pretty valuable, so i added a new file called `types.py` to contain typing constructs. I also added some string literals for various functions/methods that accept only certian string values.