### PR TITLE
Improve correlation algorithm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "probabilit"
-version = "0.4.0"
+version = "0.4.1"
 description = "A Python package for Monte Carlo sampling."
 requires-python = ">= 3.10"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/probabilit/modeling.py
+++ b/src/probabilit/modeling.py
@@ -287,7 +287,7 @@ from probabilit.correlation import (
     Composite,
     Permutation,
 )
-from probabilit.utils import build_corrmat, zip_args
+from probabilit.utils import zip_args
 from probabilit.garbage_collector import GarbageCollector
 import copy
 
@@ -712,18 +712,16 @@ class Node(abc.ABC):
 
         # If there are any correlations to induce, do so
         if correlations:
-            # Induce correlations
-            correlation_matrix = build_corrmat(correlations)
-            correlation_matrix = nearest_correlation_matrix(correlation_matrix)
+            for idxs, corr_mat in correlations:
+                corr_mat = nearest_correlation_matrix(np.asarray(corr_mat))
+                group_correlator = correlator.set_target(corr_mat)
 
-            # Set the target (goal) correlation matrix
-            correlator = correlator.set_target(correlation_matrix)
+                # Stack only this group's variables, correlate, then write back
+                samples_input = np.vstack([corr_variables[i].samples_ for i in idxs]).T
+                samples_output = group_correlator(samples_input)
 
-            # Concatenate samples, correlate them (shift rows in each col), then re-assign
-            samples_input = np.vstack([var.samples_ for var in corr_variables]).T
-            samples_ouput = correlator(samples_input)
-            for var, sample in zip(corr_variables, samples_ouput.T):
-                var.samples_ = np.copy(sample)
+                for i, sample in zip(idxs, samples_output.T):
+                    corr_variables[i].samples_ = np.copy(sample)
 
         # Sample all the way to the end. In this graph:
         # A ----> B ---> [C] ---> D
@@ -731,6 +729,7 @@ class Node(abc.ABC):
         #                         v
         # E ---> [F] ---> G ----> result
         # this would mean sampling from D and G.
+
         topo_sample(self.to_graph(), gc=gc, garbage_collected=garbage_collected)
         return self.samples_
 

--- a/src/probabilit/modeling.py
+++ b/src/probabilit/modeling.py
@@ -690,7 +690,7 @@ class Node(abc.ABC):
         variable_sets = [set(variables) for (variables, _) in correlations]
         for vars1, vars2 in itertools.combinations(variable_sets, 2):
             common = vars1.intersection(vars2)
-            if len(common) > 1:
+            if len(common) >= 1:
                 raise ValueError(f"Correlations specified more than once: {common}")
 
         # Sample up until nodes that we induce correlations on. In this graph:

--- a/src/probabilit/modeling.py
+++ b/src/probabilit/modeling.py
@@ -690,7 +690,7 @@ class Node(abc.ABC):
         variable_sets = [set(variables) for (variables, _) in correlations]
         for vars1, vars2 in itertools.combinations(variable_sets, 2):
             common = vars1.intersection(vars2)
-            if len(common) >= 1:
+            if common:
                 raise ValueError(f"Correlations specified more than once: {common}")
 
         # Sample up until nodes that we induce correlations on. In this graph:

--- a/src/probabilit/modeling.py
+++ b/src/probabilit/modeling.py
@@ -713,7 +713,7 @@ class Node(abc.ABC):
         # If there are any correlations to induce, do so
         if correlations:
             for idxs, corr_mat in correlations:
-                corr_mat = nearest_correlation_matrix(np.asarray(corr_mat))
+                corr_mat = nearest_correlation_matrix(np.array(corr_mat))
                 group_correlator = correlator.set_target(corr_mat)
 
                 # Stack only this group's variables, correlate, then write back

--- a/src/probabilit/utils.py
+++ b/src/probabilit/utils.py
@@ -90,31 +90,6 @@ def zip_args(args, kwargs):
         yield args_i, dict(zip(kwargs.keys(), kwargs_i))
 
 
-def build_corrmat(correlations):
-    """Given a list of [(indices1, corrmat1), (indices2, corrmat2), ...],
-    create a big correlation matrix.
-
-    Examples
-    --------
-    >>> correlations = [((0, 2), np.array([[1, 0.5], [0.5, 1]]))]
-    >>> build_corrmat(correlations)
-    array([[1. , 0. , 0.5],
-           [0. , 1. , 0. ],
-           [0.5, 0. , 1. ]])
-    """
-    # TODO: If no correlation is given, we implicitly assume zero.
-    # For instance, if no correlation between indices (0, 3) is given
-    # in the input data, then C[0, 3] = C[3, 0] = 0.0, which is strictly
-    # speaking not the same (no preference vs. preference for 0 corr)
-    n = max(max(idx) for (idx, _) in correlations)
-    C = np.eye(n + 1, dtype=float)
-
-    for idx_i, corrmat_i in correlations:
-        C[np.ix_(idx_i, idx_i)] = corrmat_i
-
-    return C
-
-
 if __name__ == "__main__":
     import pytest
 

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -12,6 +12,7 @@ from probabilit.modeling import (
     NoOp,
 )
 from probabilit.distributions import Triangular, TruncatedNormal
+from probabilit.correlation import ImanConover
 import numpy as np
 import scipy as sp
 import pytest
@@ -390,6 +391,36 @@ def test_correlations():
     desired_corr_mat[:3, :3] = corr_mat
 
     np.testing.assert_allclose(observed_corr_mat, desired_corr_mat, atol=0.075)
+
+
+def test_total_correlations_larger_than_sample_size():
+    # This test verifies that rank-based correlation induction works even when
+    # the total number of correlated variables exceeds the sample size, as
+    # long as each correlation group is smaller than the sample size.
+    a = Distribution("norm", loc=0, scale=1)
+    b = Distribution("norm", loc=0, scale=1)
+    c = Distribution("norm", loc=0, scale=1)
+    d = Distribution("norm", loc=0, scale=1)
+    e = Distribution("norm", loc=0, scale=1)
+    f = Distribution("norm", loc=0, scale=1)
+    expression = a + b + c + d + e + f
+
+    corr_mat_ab = np.array([[1.0, 0.5], [0.5, 1.0]])
+    corr_mat_cd = np.array([[1.0, -0.5], [-0.5, 1.0]])
+    corr_mat_ef = np.array([[1.0, 0.3], [0.3, 1.0]])
+
+    expression.correlate(a, b, corr_mat=corr_mat_ab)
+    expression.correlate(c, d, corr_mat=corr_mat_cd)
+    expression.correlate(e, f, corr_mat=corr_mat_ef)
+
+    expression.sample(size=5, random_state=42, method="lhs")
+
+    obs_corr_ab = np.corrcoef(np.array([a.samples_, b.samples_]))
+    obs_corr_cd = np.corrcoef(np.array([c.samples_, d.samples_]))
+    obs_corr_ef = np.corrcoef(np.array([e.samples_, f.samples_]))
+    assert np.linalg.norm(obs_corr_ab - corr_mat_ab) <= 0.15
+    assert np.linalg.norm(obs_corr_cd - corr_mat_cd) <= 0.15
+    assert np.linalg.norm(obs_corr_ef - corr_mat_ef) <= 0.15
 
 
 def test_correlations_with_derived_nodes():

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -412,14 +412,8 @@ def test_total_correlations_larger_than_sample_size():
     expression.correlate(c, d, corr_mat=corr_mat_cd)
     expression.correlate(e, f, corr_mat=corr_mat_ef)
 
+    # Smoketest, this should not raise an error
     expression.sample(size=5, random_state=42, method="lhs")
-
-    obs_corr_ab = np.corrcoef(np.array([a.samples_, b.samples_]))
-    obs_corr_cd = np.corrcoef(np.array([c.samples_, d.samples_]))
-    obs_corr_ef = np.corrcoef(np.array([e.samples_, f.samples_]))
-    assert np.linalg.norm(obs_corr_ab - corr_mat_ab) <= 0.15
-    assert np.linalg.norm(obs_corr_cd - corr_mat_cd) <= 0.15
-    assert np.linalg.norm(obs_corr_ef - corr_mat_ef) <= 0.15
 
 
 def test_correlations_with_derived_nodes():

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -412,7 +412,7 @@ def test_total_correlations_larger_than_sample_size():
     expression.correlate(c, d, corr_mat=corr_mat_cd)
     expression.correlate(e, f, corr_mat=corr_mat_ef)
 
-    # Smoketest, this should not raise an error
+    # Smoketest. Should not raise even though samples < variables
     expression.sample(size=5, random_state=42, method="lhs")
 
 

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -12,7 +12,6 @@ from probabilit.modeling import (
     NoOp,
 )
 from probabilit.distributions import Triangular, TruncatedNormal
-from probabilit.correlation import ImanConover
 import numpy as np
 import scipy as sp
 import pytest

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -416,6 +416,24 @@ def test_total_correlations_larger_than_sample_size():
     expression.sample(size=5, random_state=42, method="lhs")
 
 
+def test_error_when_overlapping_correlations():
+    a = Distribution("norm", loc=0, scale=1)
+    b = Distribution("norm", loc=0, scale=1)
+    c = Distribution("norm", loc=0, scale=1)
+    expression = a + b + c
+
+    corr_mat_ab = np.array([[1.0, 0.5], [0.5, 1.0]])
+    corr_mat_ac = np.array([[1.0, -0.5], [-0.5, 1.0]])
+
+    expression.correlate(a, b, corr_mat=corr_mat_ab)
+    expression.correlate(a, c, corr_mat=corr_mat_ac)
+
+    # Sampling should raise an error due to overlapping
+    # correlation groups
+    with pytest.raises(ValueError):
+        expression.sample(size=5, random_state=42, method="lhs")
+
+
 def test_correlations_with_derived_nodes():
     # Two distributions can be correlated
     a = Distribution("norm", loc=0, scale=1)


### PR DESCRIPTION
Issue:

> My problem is that those 203 realizations that I want to correlate are not defined by me as one large correlation matrix. These are split among 5-6 independent of each other correlations matrices. Seem like probabilit puts all of them together, which makes it statistically impossible to solve and the library gives an error. So this "feature" of probabilit is not nice, because I do not want to have 204 realizations. I want to have 200.

**Tommys comment**: the issue is that if a user specifices correlation between A and B, then between A and C, probabilit will create a large correlation matrix with a zero entry between B and C. It will then try to drive this value down to zero. This is additional work AND it requires more samples, because we need more samples than variables for Cholesky to be well defined in the Iman Conover algorithm.