### PR TITLE
Fix Iman-Conover marginal preservation with ties

### DIFF
--- a/src/probabilit/correlation.py
+++ b/src/probabilit/correlation.py
@@ -434,7 +434,10 @@ class ImanConover(Correlator):
         for k in range(K):
             # If row j is the k'th largest in `correlated_scores`, then
             # we map the k'th largest entry in X to row j.
-            ranks = sp.stats.rankdata(correlated_scores[:, k]).astype(int) - 1
+            ranks = (
+                sp.stats.rankdata(correlated_scores[:, k], method="ordinal").astype(int)
+                - 1
+            )
             result[:, k] = np.sort(X[:, k])[ranks]
 
         return result

--- a/tests/test_iman_conover.py
+++ b/tests/test_iman_conover.py
@@ -38,6 +38,16 @@ def test_preserves_marginal_distributions(rng, sample_data):
         assert np.allclose(np.sort(X[:, k]), np.sort(X_transformed[:, k]))
 
 
+def test_preserves_marginal_distributions_with_ties():
+    X = np.array([[0, 0]] * 2 + [[0, 1]] * 3 + [[1, 0]] * 2 + [[1, 1]] * 3)
+    sorted_samples = np.sort(X, axis=0)
+    C = np.corrcoef(sorted_samples, rowvar=False)
+
+    X_transformed = ImanConover().set_target(C)(X)
+
+    np.testing.assert_array_equal(np.sort(X_transformed, axis=0), sorted_samples)
+
+
 def test_achieves_target_correlations(sample_data):
     X, C = sample_data
 


### PR DESCRIPTION
See for instance https://blogs.sas.com/content/iml/2021/06/14/simulate-iman-conover-transformation.html
`ImanConover` should change correlation by permuting samples within each column, without altering the sampled values or their frequencies.
 
 The final reordering previously used average ranks for tied transformed scores. Converting these to integer indices could reuse some positions and skip others, changing the marginal distributions. This PR uses `method="ordinal"` so the final mapping is a true permutation and every original observation is preserved.